### PR TITLE
Add some hack to fix window size, shadow, position problem.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${QT_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR})
 
 SET(fcitx-kimpanel_RCCS qml.qrc)
-set(fcitx-kimpanel_SRCS main.cpp main_controller.cpp 
+set(fcitx-kimpanel_SRCS main.cpp main_controller.cpp toplevel.cpp
     main_model.cpp kimpanelagent.cpp candidate_word.cpp system_tray_menu.cpp)
 QT4_ADD_DBUS_ADAPTOR(fcitx-kimpanel_SRCS
     org.kde.impanel.xml

--- a/main.qml
+++ b/main.qml
@@ -5,8 +5,9 @@ Rectangle {
     height: layout.height + 5
     id: mainWindow
     objectName: "mainWindowQml"
+
     border.color: "#0080FF"
-    border.width: 2
+    border.width: 1
     
     Row {
         id: layout

--- a/main_controller.h
+++ b/main_controller.h
@@ -10,6 +10,7 @@
 #include "main_model.h"
 #include "system_tray_menu.h"
 #include "kimpanelagent.h"
+#include "toplevel.h"
 
 class MainController : public QApplication
 {
@@ -21,6 +22,7 @@ public:
     bool init();
 
 private:
+    TopLevel* mTopLevel;
     MainModel *mModel;
     PanelAgent *mAgent;
     QDeclarativeView *mView;

--- a/toplevel.cpp
+++ b/toplevel.cpp
@@ -1,0 +1,107 @@
+/***************************************************************************
+ *   Copyright (C) 2013 by CSSlayer <wengxt@gmail.com>                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
+ ***************************************************************************/
+
+#include <QBoxLayout>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QEvent>
+
+#include "toplevel.h"
+
+TopLevel::TopLevel(QWidget* parent) : QWidget(parent,
+                                              Qt::Tool | Qt::WindowStaysOnTopHint
+                                            | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint)
+{
+    setAttribute(Qt::WA_TranslucentBackground, true);
+    QVBoxLayout *lay = new QVBoxLayout(this);
+    lay->setMargin(0);
+    lay->setSpacing(0);
+    setLayout(lay);
+
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+}
+
+void TopLevel::setCenterWidget(QWidget* widget)
+{
+    if (m_widget) {
+        m_widget->removeEventFilter(this);
+        layout()->removeWidget(m_widget);
+    }
+    m_widget = widget;
+    widget->installEventFilter(this);
+    widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    layout()->addWidget(widget);
+    layout()->activate();
+}
+
+void TopLevel::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    setMask(rect());
+    updateLocation();
+}
+
+bool TopLevel::eventFilter(QObject* object, QEvent* event)
+{
+    if (object == m_widget.data() &&
+        event->type() == QEvent::Resize) {
+        setMinimumSize(m_widget->sizeHint());
+        setMaximumSize(m_widget->sizeHint());
+    }
+    return QObject::eventFilter(object, event);
+}
+
+void TopLevel::resizeEvent(QResizeEvent* resize)
+{
+    QWidget::resizeEvent(resize);
+    setMask(rect());
+    updateLocation();
+}
+
+void TopLevel::setSpotRect(const QRect& rect)
+{
+    m_spotRect = rect;
+    updateLocation();
+}
+
+void TopLevel::updateLocation()
+{
+    QRect screenRect = QApplication::desktop()->screenGeometry(QPoint(m_spotRect.x(), m_spotRect.y()));
+    int x;
+    x = qMin(m_spotRect.x(), screenRect.x() + screenRect.width() - width());
+    x = qMax(x, screenRect.x());
+    int oy = m_spotRect.y() + m_spotRect.height();
+    int y = oy + 10;
+    if (y < screenRect.y()) {
+        y = screenRect.y();
+    }
+
+    if (y > screenRect.y() + screenRect.height()) {
+        y = screenRect.height();
+    }
+
+    if (y + height() > screenRect.y() + screenRect.height()) {
+        /// minus 20 to make preedit bar never overlap the input context
+        y = oy - (height() + ((m_spotRect.height() == 0)?20:(m_spotRect.height() + 10)));
+    }
+
+    QPoint p(x, y);
+    if (p != pos())
+        move(p);
+}

--- a/toplevel.h
+++ b/toplevel.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *   Copyright (C) 2013 by CSSlayer <wengxt@gmail.com>                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .        *
+ ***************************************************************************/
+
+#ifndef _TOPLEVEL_H_
+#define _TOPLEVEL_H_
+
+#include <QWidget>
+#include <QPointer>
+
+class TopLevel : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit TopLevel(QWidget* parent = 0);
+
+    void setCenterWidget(QWidget* widget);
+    virtual void showEvent(QShowEvent* event);
+    virtual void resizeEvent(QResizeEvent* resize);
+    virtual bool eventFilter(QObject* object, QEvent* event);
+    void setSpotRect(const QRect& rect);
+private:
+    void updateLocation();
+
+    QPointer<QWidget> m_widget;
+    QRect m_spotRect;
+};
+
+#endif


### PR DESCRIPTION
Fix window size when window will be drawn out side of screen.
Hack window position by an additional toplevel widget.
using resizeEvent to listen the size change, setMask to override
posible kwin shadow. Using event filter to resize the window to
correct size.
