### PR TITLE
Typo fix cannel -> cancel

### DIFF
--- a/config-tool/editingskindialog.cpp
+++ b/config-tool/editingskindialog.cpp
@@ -64,7 +64,7 @@ EditingSkinDialog::EditingSkinDialog(bool pHorizontal,QListWidgetItem *item,
     ui->label_iAdjustWidth->setText(gettext("AdjustWidth"));
     ui->label_iAdjustHeight->setText(gettext("AdjustHeight"));
 
-    ui->pushButton_cannel->setText(gettext("&Cannel"));
+    ui->pushButton_cancel->setText(gettext("&Cancel"));
     ui->pushButton_ok->setText(gettext("&Ok"));
     ui->pushButton_refresh->setText(gettext("&Refresh"));
 
@@ -290,7 +290,7 @@ void EditingSkinDialog::on_pushButton_ok_released()
     this->close();
 }
 
-void EditingSkinDialog::on_pushButton_cannel_released()
+void EditingSkinDialog::on_pushButton_cancel_released()
 {
     this->close();
 }

--- a/config-tool/editingskindialog.h
+++ b/config-tool/editingskindialog.h
@@ -23,7 +23,7 @@ private slots:
     void on_pushButtonInputColor_released();
     void on_pushButton_ok_released();
     void on_pushButton_refresh_released();
-    void on_pushButton_cannel_released();
+    void on_pushButton_cancel_released();
     void on_pushButtonIndexColor_released();
     void on_pushButtonFirstCandColor_released();
     void on_pushButtonOtherCandColor_released();

--- a/config-tool/editingskindialog.ui
+++ b/config-tool/editingskindialog.ui
@@ -859,7 +859,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButton_cannel">
+        <widget class="QPushButton" name="pushButton_cancel">
          <property name="maximumSize">
           <size>
            <width>100</width>
@@ -873,7 +873,7 @@
           </size>
          </property>
          <property name="text">
-          <string>&amp;Cannel</string>
+          <string>&amp;Cancel</string>
          </property>
         </widget>
        </item>

--- a/po/fcitx-qimpanel.pot
+++ b/po/fcitx-qimpanel.pot
@@ -134,7 +134,7 @@ msgid "AdjustHeight"
 msgstr ""
 
 #: config-tool/editingskindialog.cpp:67
-msgid "&Cannel"
+msgid "&Cancel"
 msgstr ""
 
 #: config-tool/editingskindialog.cpp:68

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -134,7 +134,7 @@ msgid "AdjustHeight"
 msgstr "面板高度调节"
 
 #: config-tool/editingskindialog.cpp:67
-msgid "&Cannel"
+msgid "&Cancel"
 msgstr "取消"
 
 #: config-tool/editingskindialog.cpp:68


### PR DESCRIPTION
Correct the typo "Cannel" with "Cancel".

This fixes issue #41 
