### PR TITLE
fixed it for multilingual support.(fcitx-qimpanel-configtool.desktop)

### DIFF
--- a/config-tool/fcitx-qimpanel-configtool.desktop
+++ b/config-tool/fcitx-qimpanel-configtool.desktop
@@ -1,7 +1,8 @@
 [Desktop Entry]
 Name=fcitx-qimpanel-configtool
+Comment=fcitx skin configuration tool(UbuntuKylin)
 Name[zh_CN]=小企鹅皮肤配置向导
-Comment=fcitx皮肤配置向导-UbuntuKylin
+Comment[zh_CN]=fcitx皮肤配置向导-UbuntuKylin
 Exec=fcitx-qimpanel-configtool
 Icon=fcitx
 Type=Application

--- a/config-tool/fcitx-qimpanel-configtool.desktop
+++ b/config-tool/fcitx-qimpanel-configtool.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Name=fcitx-qimpanel-configtool
-Comment=fcitx skin configuration tool(UbuntuKylin)
+Comment=fcitx skin configuration tool
+Name[ja_JP]=fcitx スキンの設定
+Comment[ja_JP]=fcitx スキンの設定をします
 Name[zh_CN]=小企鹅皮肤配置向导
 Comment[zh_CN]=fcitx皮肤配置向导-UbuntuKylin
 Exec=fcitx-qimpanel-configtool


### PR DESCRIPTION
In Japanese environment, meaning is not understood even if the tooltip is displayed in Chinese in the main menu. This application is not used in the Japanese environment. But it is part of the input method so it will be installed.
